### PR TITLE
Update for Seurat v3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.rds
+*.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # SeuratGallery
-Local shiny viewer for pre-computed Seurat objects
+Local shiny viewer for pre-computed Seurat objects (version 3).
 
-Download app.R and put in a directory along with pre-computed 10X pancreas seurat object from Satija lab website: https://www.dropbox.com/s/av5p7d3ro4m0fb5/pancreas.Rda?dl=1
+Download app.R and put in a directory along with pre-computed 10X pancreas seurat object from Satija lab website (https://satijalab.org/seurat/vignettes.html): https://www.dropbox.com/s/63gnlw45jf7cje8/pbmc3k_final.rds?dl=0
 
-Make sure you have an updated version of RStudio and Shiny installed, then double-click the app.R to open. The pancreas dataset with be loaded as a demo.
+Make sure you have an updated version of RStudio and Shiny installed, then double-click the app.R to open. The pbmc3k dataset with be loaded as a demo.
 
-To view other datasets, use the file selector to load a pre-computer Seurat object.
+To view other datasets, use the file selector to load a pre-computer Seurat object (version 3 compatible).


### PR DESCRIPTION
The current master branch assumes Seurat version 2, the recent update made some fairly substantial changes to the Seurat object. I have made some changes to make the app work with version 3 objects. However, I'm not sure how to make it backwards compatible so you may not want this pull request. 
Changes made: 

- changed demo file to version 3 object. The new demo file is a .rds file so I changed the load() functions to readRDS().
- visualised UMAP rather than tSNE (as this was the dimension reduction in the v3 demo object.
- Restructured server() function so that dataset only loads once.

